### PR TITLE
Relax the requirements for Stripe version for one more version

### DIFF
--- a/stripe-ruby-mock.gemspec
+++ b/stripe-ruby-mock.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ['lib']
 
-  gem.add_dependency 'stripe', '> 5', '< 8'
+  gem.add_dependency 'stripe', '> 5', '< 9'
   gem.add_dependency 'multi_json', '~> 1.0'
   gem.add_dependency 'dante', '>= 0.2.0'
 


### PR DESCRIPTION
To unblock the upgrade for the Stripe 8.0 SDK.