### PR TITLE
Relax max Stripe version up to version 10

### DIFF
--- a/stripe-ruby-mock.gemspec
+++ b/stripe-ruby-mock.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ['lib']
 
-  gem.add_dependency 'stripe', '> 5', '< 9'
+  gem.add_dependency 'stripe', '> 5', '< 10'
   gem.add_dependency 'multi_json', '~> 1.0'
   gem.add_dependency 'dante', '>= 0.2.0'
 


### PR DESCRIPTION
Stripe has changed their versioning strategy and now the versions come out pretty frequently. We have already reached version 9, but we can't use it because of the dependency requirements! This PR intends to fix this misconception.