### PR TITLE
Remove Stripe gem max version constraint

### DIFF
--- a/stripe-ruby-mock.gemspec
+++ b/stripe-ruby-mock.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ['lib']
 
-  gem.add_dependency 'stripe', '> 5', '< 10'
+  gem.add_dependency 'stripe', '> 5'
   gem.add_dependency 'multi_json', '~> 1.0'
   gem.add_dependency 'dante', '>= 0.2.0'
 


### PR DESCRIPTION
Stripe versioning strategy has changed and they are bumping the major version way more frequently now.
Getting rid of max version constraint to unblock further upgrades.