### PR TITLE
Add a new parameter to mocked Stripe request like was it's done by Stripe gem

### DIFF
--- a/lib/stripe_mock/instance.rb
+++ b/lib/stripe_mock/instance.rb
@@ -106,7 +106,7 @@ module StripeMock
       @base_strategy = TestStrategies::Base.new
     end
 
-    def mock_request(method, url, api_key: nil, api_base: nil, params: {}, headers: {})
+    def mock_request(method, url, api_key: nil, api_base: nil, params: {}, headers: {}, usage: [])
       return {} if method == :xtest
 
       api_key ||= (Stripe.api_key || DUMMY_API_KEY)


### PR DESCRIPTION
Starting from version 10.3.0, stripe-ruby-mock is not compatible with the official SDK unless this parameter is present.