### PR TITLE
[GROW-59867] Natively handle discounts array param on subscription handlers

### DIFF
--- a/lib/stripe_mock/request_handlers/subscriptions.rb
+++ b/lib/stripe_mock/request_handlers/subscriptions.rb
@@ -39,6 +39,8 @@ module StripeMock
         stripe_account = headers && headers[:stripe_account] || Stripe.api_key
         route =~ method_url
 
+        normalize_discounts_param(params)
+
         subscription_plans = get_subscription_plans_from_params(params)
         customer = assert_existence :customer, $1, customers[stripe_account][$1]
 
@@ -95,6 +97,8 @@ module StripeMock
           end
         end
         route =~ method_url
+
+        normalize_discounts_param(params)
 
         subscription_plans = get_subscription_plans_from_params(params)
 
@@ -227,6 +231,8 @@ module StripeMock
         stripe_account = headers && headers[:stripe_account] || Stripe.api_key
         route =~ method_url
 
+        normalize_discounts_param(params, allow_removal: true)
+
         if params[:billing_cycle_anchor] == 'now'
           params[:billing_cycle_anchor] = Time.now.utc.to_i
         end
@@ -357,6 +363,33 @@ module StripeMock
       end
 
       private
+
+      # Translate the modern `discounts: [{ coupon: <id> }]` / `[{ promotion_code: <id> }]`
+      # array param into the legacy `coupon:` / `promotion_code:` params the handlers
+      # already process, so no downstream coupon/discount logic has to change.
+      #
+      # `discounts` normally arrives as a plain array, but the Stripe SDK can serialize
+      # an array of hashes as a hash keyed by index, e.g. `{ 0 => {...} }` — the same
+      # shape `items` can arrive in — so it is normalized with `.values` defensively.
+      #
+      # When `allow_removal` is set (update only), an empty `discounts` (`''` or `[]`)
+      # is translated into `coupon: ''` so the existing removal branch clears the
+      # discount. It is left off for creates so an empty array does not synthesise an
+      # empty-string coupon lookup.
+      def normalize_discounts_param(params, allow_removal: false)
+        return unless params.key?(:discounts)
+
+        discounts = params.delete(:discounts)
+        normalized = discounts.respond_to?(:values) ? discounts.values : discounts
+        entry = Array(normalized).first
+
+        if entry.is_a?(Hash)
+          params[:coupon] = entry[:coupon] if entry.key?(:coupon)
+          params[:promotion_code] = entry[:promotion_code] if entry.key?(:promotion_code)
+        elsif allow_removal && (normalized.nil? || normalized == '' || (normalized.respond_to?(:empty?) && normalized.empty?))
+          params[:coupon] = ''
+        end
+      end
 
       def get_subscription_plans_from_params(params)
         plan_ids = if params[:plan]

--- a/spec/shared_stripe_examples/subscription_examples.rb
+++ b/spec/shared_stripe_examples/subscription_examples.rb
@@ -196,6 +196,34 @@ shared_examples 'Customer Subscriptions with plans' do
       }
     end
 
+    it 'contains coupon object when passed via the discounts array', live: true do
+      coupon = stripe_helper.create_coupon(id: 'free_coupon', duration: 'repeating', duration_in_months: 3)
+      customer = Stripe::Customer.create(source: gen_card_tk)
+      Stripe::Subscription.create(plan: plan.id, customer: customer.id, discounts: [{ coupon: coupon.id }])
+      customer = Stripe::Customer.retrieve(customer.id)
+
+      subscriptions = Stripe::Subscription.list(customer: customer.id)
+
+      expect(subscriptions.data).to be_a(Array)
+      expect(subscriptions.data.count).to eq(1)
+      expect(subscriptions.data.first.discount).not_to be_nil
+      expect(subscriptions.data.first.discount.id).not_to be_nil
+      expect(subscriptions.data.first.discount).to be_a(Stripe::Discount)
+      expect(subscriptions.data.first.discount.coupon.id).to eq(coupon.id)
+    end
+
+    it 'when coupon passed via the discounts array does not exist' do
+      customer = Stripe::Customer.create(source: gen_card_tk)
+
+      expect {
+        Stripe::Subscription.create(plan: plan.id, customer: customer.id, discounts: [{ coupon: 'none' }])
+      }.to raise_error {|e|
+        expect(e).to be_a Stripe::InvalidRequestError
+        expect(e.http_status).to eq(400)
+        expect(e.message).to eq('No such coupon: none')
+      }
+    end
+
     it "allows promotion code" do
       customer = Stripe::Customer.create(source: gen_card_tk)
       coupon = stripe_helper.create_coupon
@@ -203,6 +231,16 @@ shared_examples 'Customer Subscriptions with plans' do
 
       expect {
         Stripe::Subscription.create(plan: plan.id, customer: customer.id, promotion_code: promotion_code.id)
+      }.not_to raise_error
+    end
+
+    it "allows promotion code passed via the discounts array" do
+      customer = Stripe::Customer.create(source: gen_card_tk)
+      coupon = stripe_helper.create_coupon
+      promotion_code = Stripe::PromotionCode.create(coupon: coupon)
+
+      expect {
+        Stripe::Subscription.create(plan: plan.id, customer: customer.id, discounts: [{ promotion_code: promotion_code.id }])
       }.not_to raise_error
     end
 
@@ -965,6 +1003,47 @@ shared_examples 'Customer Subscriptions with plans' do
       subscription.coupon = coupon.id
       subscription.save
       subscription.coupon = nil
+      subscription.save
+
+      expect(subscription.discount).to be_nil
+    end
+
+    it 'when adds coupon via the discounts array', live: true do
+      coupon = stripe_helper.create_coupon
+      customer = Stripe::Customer.create(source: gen_card_tk, plan: plan.id)
+      subscription = Stripe::Subscription.retrieve(customer.subscriptions.data.first.id)
+
+      subscription.discounts = [{ coupon: coupon.id }]
+      subscription.save
+
+      expect(subscription.discount).not_to be_nil
+      expect(subscription.discount).to be_a(Stripe::Discount)
+      expect(subscription.discount.coupon.id).to eq(coupon.id)
+    end
+
+    it 'when adds not exist coupon via the discounts array' do
+      customer = Stripe::Customer.create(source: gen_card_tk, plan: plan.id)
+      subscription = Stripe::Subscription.retrieve(customer.subscriptions.data.first.id)
+
+      subscription.discounts = [{ coupon: 'none' }]
+
+      expect { subscription.save }.to raise_error {|e|
+                                                     expect(e).to be_a Stripe::InvalidRequestError
+                                                     expect(e.http_status).to eq(400)
+                                                     expect(e.message).to eq('No such coupon: none')
+                                                   }
+    end
+
+    it 'when coupon is removed via the discounts array' do
+      customer = Stripe::Customer.create(source: gen_card_tk, plan: plan.id)
+      coupon = stripe_helper.create_coupon
+      subscription = Stripe::Subscription.retrieve(customer.subscriptions.data.first.id)
+
+      subscription.discounts = [{ coupon: coupon.id }]
+      subscription.save
+      expect(subscription.discount).not_to be_nil
+
+      subscription.discounts = []
       subscription.save
 
       expect(subscription.discount).to be_nil


### PR DESCRIPTION
## Summary
**GROW-59867** — Teaches the GlossGenius `stripe-ruby-mock` fork to handle the modern Stripe `discounts: [{ coupon: <code> }]` / `[{ promotion_code: <code> }]` array param on the subscription handlers, translating it into the legacy `coupon:` / `promotion_code:` flow the mock already implements.

## Context
This unblocks core-api PR #11135, which switched `apply_coupon.rb` to send `discounts:` unconditionally because Stripe's flexible-billing mode rejects the legacy `coupon:` param on subscription updates. That PR carries a temporary monkey-patch (`spec/support/stripe_mock_discounts_patch.rb`) to keep its tests green; making the translation first-class in the fork lets that patch be removed once this merges and the gem revision is bumped in core-api (follow-up, out of scope here). Reviewer reference: https://github.com/GlossGenius/core-api/pull/11135#discussion_r3423425821

---
<!-- linear-id: GROW-59867 -->
Implements GROW-59867.
Reported by melvin.nguyen@glossgenius.com.

🧞‍♂️ Created by Geni — [Watch me work in real-time](https://platform.claude.com/workspaces/wrkspc_01H9CDqX61QWvKdmu9VKv42D/sessions/sesn_01S6fiz9AhzCo5NrsQdHc1jA)
